### PR TITLE
Upgrade to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Antti Keränen <detegr@gmail.com>"]
 
 [dependencies]
-nom = "*"
+nom = "~1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,13 @@ impl std::error::Error for ParserError {
         &self.data
     }
 }
-impl<'a> From<nom::Err<'a>> for ParserError {
-    fn from(e: nom::Err) -> ParserError {
+impl<'a> From<nom::Err<&'a[u8]>> for ParserError {
+    fn from(e: nom::Err<&'a[u8]>) -> ParserError {
         match e {
-            nom::Err::Position(pos, data) => {
+            nom::Err::Position(error, data) => {
                 ParserError {
-                    data: format!("Error at position {}: '{}'",
-                                  pos,
+                    data: format!("Error '{:?}' at position {}",
+                                  error,
                                   String::from_utf8_lossy(data))
                     }
                 }


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
